### PR TITLE
Update app.py: Trio example in docstring

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -383,8 +383,13 @@ Trio example
 
     from kivy.app import async_runTouchApp
     from kivy.uix.label import Label
-
-    trio.run(async_runTouchApp, Label(text='Hello, World!'), async_lib='trio')
+    
+    from functools import partial
+    
+    # use functools.partial() to pass keyword arguments:
+    async_runTouchApp_func = partial(async_runTouchApp, async_lib='trio')
+    
+    trio.run(async_runTouchApp_func, Label(text='Hello, World!'), async_lib='trio')
 
 Interacting with Kivy app from other coroutines
 -----------------------------------------------


### PR DESCRIPTION
It doesn't work without, as `trio.run()` [says](https://trio.readthedocs.io/en/stable/reference-core.html):
If you need to pass keyword arguments, then use `functools.partial()`.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
